### PR TITLE
Wrap all output in a containerdebug span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- All output is now wrapped in a "containerdebug" span ([#18]).
+
+[#18]: https://github.com/stackabletech/containerdebug/pull/18
+
 ## [0.1.0] - 2024-12-09
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,10 @@ fn main() {
         APP_NAME,
         opts.tracing_target,
     );
+
+    // Wrap *all* output in a span, to separate it from main app output.
+    let _span = tracing::error_span!("containerdebug").entered();
+
     stackable_operator::utils::print_startup_string(
         crate_description!(),
         crate_version!(),
@@ -62,7 +66,6 @@ fn main() {
         let system_information = SystemInformation::collect();
 
         let serialized = serde_json::to_string_pretty(&system_information).unwrap();
-        // println!("{serialized}");
         if let Some(output_path) = &opts.output {
             std::fs::write(output_path, &serialized).unwrap();
         }


### PR DESCRIPTION
# Description

After some discussion from Slack (https://stackable-workspace.slack.com/archives/C031A5Z9542/p1733999979523619) it was mentioned that containerdebug output could be confused with output from the app itself. This should hopefully help highlight the difference a bit further.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```