### PR TITLE
Cache sysinfo data, and only query for the data we actually use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ All notable changes to this project will be documented in this file.
 - Downgraded DNS errors to warnings ([#17]).
 - All output is now wrapped in a "containerdebug" span ([#18]).
 
+### Fixes
+
+- Reduced memory usage dramatically by limiting and caching fetched information ([#20]).
+
 [#17]: https://github.com/stackabletech/containerdebug/pull/17
 [#18]: https://github.com/stackabletech/containerdebug/pull/18
+[#20]: https://github.com/stackabletech/containerdebug/pull/20
 
 ## [0.1.0] - 2024-12-09
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,8 @@ fn main() {
         built_info::RUSTC_VERSION,
     );
 
+    let mut collect_ctx = SystemInformation::init();
+
     let mut next_run = Instant::now();
     loop {
         let next_run_sleep = next_run.saturating_duration_since(Instant::now());
@@ -59,7 +61,7 @@ fn main() {
         }
         std::thread::sleep(next_run_sleep);
 
-        let system_information = SystemInformation::collect();
+        let system_information = SystemInformation::collect(&mut collect_ctx);
 
         let serialized = serde_json::to_string_pretty(&system_information).unwrap();
         // println!("{serialized}");

--- a/src/system_information/resources.rs
+++ b/src/system_information/resources.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use sysinfo::System;
+use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
 #[derive(Debug, Serialize)]
 pub struct Resources {
@@ -22,9 +22,15 @@ pub struct Resources {
 
 impl Resources {
     #[tracing::instrument(name = "Resources::collect", skip(sys))]
-    pub fn collect(sys: &System) -> Self {
+    pub fn collect(sys: &mut System) -> Self {
         // This style of "declare-then-log-then-merge becomes a bit verbose,
         // but should help keep each log statement local to where that info is collected.
+
+        sys.refresh_specifics(
+            RefreshKind::new()
+                .with_cpu(CpuRefreshKind::new().with_cpu_usage())
+                .with_memory(MemoryRefreshKind::everything()),
+        );
 
         let cpu_count = sys.cpus().len();
         let physical_core_count = sys.physical_core_count();


### PR DESCRIPTION
# Description

Fixes #19. There's still room for improvement, but on my desktop this takes us from ~50MiB on startup and ~95MiB steady state, to ~8MiB steady state.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```