### PR TITLE
fix: Replace long running span with short lived spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Increased the default `--loop` interval from every minute to every 30 minutes ([#23]).
-- Collect and output the open files limit ([#45])
+- Collect and output the open files limit ([#45]).
+
+### Fixes
+
+- Move the span inside the loop ([#46]).
 
 [#23]: https://github.com/stackabletech/containerdebug/pull/23
 [#45]: https://github.com/stackabletech/containerdebug/pull/45
+[#46]: https://github.com/stackabletech/containerdebug/pull/46
 
 ## [0.1.1] - 2024-12-16
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,7 @@ fn main() {
         .init()
         .unwrap();
 
-    // Wrap *all* output in a span, to separate it from main app output.
-    let _span = tracing::error_span!("containerdebug").entered();
+    let init_span = tracing::error_span!("containerdebug init").entered();
 
     stackable_operator::utils::print_startup_string(
         crate_description!(),
@@ -58,7 +57,12 @@ fn main() {
     let mut collect_ctx = SystemInformation::init();
 
     let mut next_run = Instant::now();
+
+    drop(init_span);
     loop {
+        // Wrap *all* output in a span, to separate it from main app output.
+        let _span = tracing::error_span!("containerdebug run").entered();
+
         let next_run_sleep = next_run.saturating_duration_since(Instant::now());
         if !next_run_sleep.is_zero() {
             tracing::info!(?next_run, "scheduling next run...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod error;
 mod system_information;
 
-use clap::{Parser, crate_description, crate_version};
+use clap::Parser;
 use stackable_operator::telemetry::Tracing;
 use std::path::PathBuf;
 
@@ -45,13 +45,14 @@ fn main() {
 
     let init_span = tracing::error_span!("containerdebug init").entered();
 
-    stackable_operator::utils::print_startup_string(
-        crate_description!(),
-        crate_version!(),
-        built_info::GIT_VERSION,
-        built_info::TARGET,
-        built_info::BUILT_TIME_UTC,
-        built_info::RUSTC_VERSION,
+    tracing::info!(
+        built_info.pkg_version = built_info::PKG_VERSION,
+        built_info.git_version = built_info::GIT_VERSION,
+        built_info.target = built_info::TARGET,
+        built_info.built_time_utc = built_info::BUILT_TIME_UTC,
+        built_info.rustc_version = built_info::RUSTC_VERSION,
+        "Starting {name}",
+        name = built_info::PKG_NAME
     );
 
     let mut collect_ctx = SystemInformation::init();


### PR DESCRIPTION
# Description

Before, the span lived as long as the app ran which is discouraged for (subjectively) long-running apps. This change moves the span to inside the loop, and move existing _init_ stuff into a separate span (so that output is still distinguishable).

Also replace `stackable_operator::utils::print_startup_string` with `tracing::info!` to get the correct call-site displayed.

![image](https://github.com/user-attachments/assets/f07bd014-bc48-4604-b24e-b8f7932c6a5b)


<details><summary>Why are long spans discouraged?</summary>

Two problems arise when troubleshooting an application via tracing:

1. Long spans just have too much detail to sift through. The parent span (which is basically _the trace_) ends up with too much detail. It should be scoped down to useful "start" and "stop" points, eg:
  - The app starting up, and
  - Each iteration of the loop (there is not much value in covering the time in between runs).
2. Large traces will get rejected by having too many child spans, or just too much data (depending on the receivers configuration).

</details>

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
