### PR TITLE
chore: Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-10
+
 ### Changed
 
 - Dependency bumps. This includes switching to async code (using `tokio`), as `hickory-resolver` 0.25 removed the synchronous APIs ([#52]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "containerdebug"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "built",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerdebug"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
### Changed

- Dependency bumps. This includes switching to async code (using `tokio`), as `hickory-resolver` 0.25 removed the synchronous APIs ([#52]).

[#52]: https://github.com/stackabletech/containerdebug/pull/52
