### PR TITLE
fix: Don't log ANSI escape sequences if stdout is a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't log ANSI escape sequences if stdout is a file ([#59]).
+
+[#59]: https://github.com/stackabletech/containerdebug/pull/59
+
 ## [0.3.0] - 2026-03-10
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,7 +2634,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stackable-shared"
 version = "0.1.0"
-source = "git+https://github.com/stackabletech/operator-rs?tag=stackable-operator-0.107.0#a16cafb151202948e79925a58662b14b8b004cd7"
+source = "git+https://github.com/stackabletech/operator-rs?tag=stackable-telemetry-0.6.3#380e4fbf5ea920fef2d12c63d2c2165ac0fe2193"
 dependencies = [
  "k8s-openapi",
  "kube",
@@ -2648,8 +2648,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.6.2"
-source = "git+https://github.com/stackabletech/operator-rs?tag=stackable-operator-0.107.0#a16cafb151202948e79925a58662b14b8b004cd7"
+version = "0.6.3"
+source = "git+https://github.com/stackabletech/operator-rs?tag=stackable-telemetry-0.6.3#380e4fbf5ea920fef2d12c63d2c2165ac0fe2193"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ sysinfo = { version = "0.38", features = ["serde"] }
 tokio = { version = "1.49", default-features = false, features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
 
-stackable-shared = {git = "https://github.com/stackabletech/operator-rs", tag = "stackable-operator-0.107.0", default-features = false }
-stackable-telemetry = {git = "https://github.com/stackabletech/operator-rs", tag = "stackable-operator-0.107.0", default-features = false, features = ["clap"] }
+stackable-shared = {git = "https://github.com/stackabletech/operator-rs", tag = "stackable-telemetry-0.6.3", default-features = false }
+stackable-telemetry = {git = "https://github.com/stackabletech/operator-rs", tag = "stackable-telemetry-0.6.3", default-features = false, features = ["clap"] }
 
 [build-dependencies]
 built = { version = "0.8", features = ["chrono", "git2"] }


### PR DESCRIPTION
This PR bumps to `stackable-telemetry` 0.6.3 which fixes the ANSI escape sequence issue when logging to a file.